### PR TITLE
Load user's profile data

### DIFF
--- a/Sources/OpenGoogleSignInSDK/JSONDecoder.swift
+++ b/Sources/OpenGoogleSignInSDK/JSONDecoder.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension JSONDecoder {
+    /// Framework's setup of the `JSONDecoder`
+    /// tailored for its use
+    static let app: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }()
+}

--- a/Sources/OpenGoogleSignInSDK/Model/GoogleSignInError.swift
+++ b/Sources/OpenGoogleSignInSDK/Model/GoogleSignInError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Google sign-in error.
-public enum GoogleSignInError: Equatable {
+public enum GoogleSignInError: Error, Equatable {
     case authenticationError(Error)
     case invalidCode
     case invalidResponse
@@ -9,27 +9,7 @@ public enum GoogleSignInError: Equatable {
     case networkError(Error)
     case tokenDecodingError(Error)
     case userCancelledSignInFlow
-}
-
-extension GoogleSignInError: LocalizedError {
-    public var errorDescription: String? {
-        switch self {
-        case let .authenticationError(error):
-            return "authenticationError, underlying error \(error.localizedDescription)"
-        case .invalidCode:
-            return "invalidCode"
-        case .invalidResponse:
-            return "invalidResponse"
-        case .invalidTokenRequest:
-            return "invalidTokenRequest"
-        case let .networkError(error):
-            return "network, underlying error \(error.localizedDescription)"
-        case let .tokenDecodingError(error):
-            return "tokenDecoding, underlying error \(error.localizedDescription)"
-        case .userCancelledSignInFlow:
-            return "userCancelledSignInFlow"
-        }
-    }
+    case noProfile(Error)
 }
 
 public func == (lhs: Error, rhs: Error) -> Bool {

--- a/Sources/OpenGoogleSignInSDK/Model/GoogleSignInError.swift
+++ b/Sources/OpenGoogleSignInSDK/Model/GoogleSignInError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Google sign-in error.
-public enum GoogleSignInError: Error, Equatable {
+public enum GoogleSignInError: Equatable {
     case authenticationError(Error)
     case invalidCode
     case invalidResponse
@@ -9,6 +9,27 @@ public enum GoogleSignInError: Error, Equatable {
     case networkError(Error)
     case tokenDecodingError(Error)
     case userCancelledSignInFlow
+}
+
+extension GoogleSignInError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .authenticationError(error):
+            return "authenticationError, underlying error \(error.localizedDescription)"
+        case .invalidCode:
+            return "invalidCode"
+        case .invalidResponse:
+            return "invalidResponse"
+        case .invalidTokenRequest:
+            return "invalidTokenRequest"
+        case let .networkError(error):
+            return "network, underlying error \(error.localizedDescription)"
+        case let .tokenDecodingError(error):
+            return "tokenDecoding, underlying error \(error.localizedDescription)"
+        case .userCancelledSignInFlow:
+            return "userCancelledSignInFlow"
+        }
+    }
 }
 
 public func == (lhs: Error, rhs: Error) -> Bool {

--- a/Sources/OpenGoogleSignInSDK/Model/GoogleSignInError.swift
+++ b/Sources/OpenGoogleSignInSDK/Model/GoogleSignInError.swift
@@ -5,7 +5,6 @@ public enum GoogleSignInError: Error, Equatable {
     case authenticationError(Error)
     case invalidCode
     case invalidResponse
-    case invalidTokenRequest
     case networkError(Error)
     case tokenDecodingError(Error)
     case userCancelledSignInFlow

--- a/Sources/OpenGoogleSignInSDK/Model/GoogleUser.swift
+++ b/Sources/OpenGoogleSignInSDK/Model/GoogleUser.swift
@@ -1,9 +1,24 @@
+import Foundation
+
 /// Google sign-in user account.
 public struct GoogleUser: Codable, Equatable {
+    public struct Profile: Codable, Equatable {
+        public let id: String
+        public let email: String
+        public let verifiedEmail: Bool
+        public let name: String
+        public let givenName: String
+        public let familyName: String
+        public let picture: URL
+        public let locale: String
+        public let hd: String
+    }
+
     public let accessToken: String
     public let expiresIn: Int
     public let idToken: String
     public let refreshToken: String?
     public let scope: String
     public let tokenType: String
+    public var profile: Profile?
 }

--- a/Sources/OpenGoogleSignInSDK/Model/GoogleUser.swift
+++ b/Sources/OpenGoogleSignInSDK/Model/GoogleUser.swift
@@ -2,16 +2,46 @@ import Foundation
 
 /// Google sign-in user account.
 public struct GoogleUser: Codable, Equatable {
+    
+    /// User's profile info.
+    ///
+    /// All the properties are optional according
+    /// to the [documentation](https://googleapis.dev/nodejs/googleapis/latest/oauth2/interfaces/Schema$Userinfo.html#info).
     public struct Profile: Codable, Equatable {
-        public let id: String
-        public let email: String
-        public let verifiedEmail: Bool
-        public let name: String
-        public let givenName: String
-        public let familyName: String
-        public let picture: URL
-        public let locale: String
-        public let hd: String
+        
+        /// The obfuscated ID of the user.
+        public let id: String?
+        
+        /// The user's email address.
+        public let email: String?
+        
+        /// Boolean flag which is true if the email address is verified.
+        /// Always verified because we only return the user's primary email address.
+        public let verifiedEmail: Bool?
+        
+        /// The user's full name.
+        public let name: String?
+        
+        /// The user's first name.
+        public let givenName: String?
+        
+        /// The user's last name.
+        public let familyName: String?
+        
+        /// The user's gender.
+        public let gender: String?
+        
+        /// URL of the profile page.
+        public let link: URL?
+        
+        /// URL of the user's picture image.
+        public let picture: URL?
+        
+        /// The hosted domain e.g. example.com if the user is Google apps user.
+        public let hd: String?
+        
+        /// The user's preferred locale.
+        public let locale: String?
     }
 
     public let accessToken: String

--- a/Sources/OpenGoogleSignInSDK/OpenGoogleSignInSDK.swift
+++ b/Sources/OpenGoogleSignInSDK/OpenGoogleSignInSDK.swift
@@ -133,10 +133,7 @@ public final class OpenGoogleSignIn: NSObject {
     
     /// Decodes `GoogleUser` from OAuth 2.0 response.
     private func decodeUser(from data: Data) throws -> GoogleUser {
-        let decoder = JSONDecoder()
-        decoder.keyDecodingStrategy = .convertFromSnakeCase
-        
-        return try decoder.decode(GoogleUser.self, from: data)
+        try JSONDecoder.app.decode(GoogleUser.self, from: data)
     }
     
     /// Handles OAuth 2.0 token response.
@@ -168,9 +165,7 @@ public final class OpenGoogleSignIn: NSObject {
                     self.makeRequest(profileRequest) { result in
                         switch result {
                         case let .success(data):
-                            let decoder = JSONDecoder()
-                            decoder.keyDecodingStrategy = .convertFromSnakeCase
-                            let profile = try? decoder.decode(GoogleUser.Profile.self, from: data)
+                            let profile = try? JSONDecoder.app.decode(GoogleUser.Profile.self, from: data)
                             user.profile = profile
                             completion(.success(user))
                             

--- a/Sources/OpenGoogleSignInSDK/OpenGoogleSignInSDK.swift
+++ b/Sources/OpenGoogleSignInSDK/OpenGoogleSignInSDK.swift
@@ -140,6 +140,9 @@ public final class OpenGoogleSignIn: NSObject {
     }
     
     /// Handles OAuth 2.0 token response.
+    ///
+    /// After successful authentication we made another request
+    /// to obtain user's profile data, e.g. email and name.
     private func handleTokenResponse(using redirectUrl: URL, completion: @escaping (Result<GoogleUser, GoogleSignInError>) -> Void) {
         guard let code = self.parseCode(from: redirectUrl) else {
             completion(.failure(.invalidCode))
@@ -162,10 +165,6 @@ public final class OpenGoogleSignIn: NSObject {
                         return
                     }
                     
-                    // To obtain profile data we need to make another request.
-                    // If the request fails, we only log the error
-                    // and call completion with the `GoogleUser` object
-                    // without his profile info.
                     self.makeRequest(profileRequest) { result in
                         switch result {
                         case let .success(data):
@@ -176,8 +175,7 @@ public final class OpenGoogleSignIn: NSObject {
                             completion(.success(user))
                             
                         case let .failure(error):
-                            os_log(.error, "Profile request failed with error: %@", error.localizedDescription)
-                            completion(.success(user))
+                            completion(.failure(.noProfile(error)))
                         }
                     }
                 } catch {

--- a/Sources/OpenGoogleSignInSDK/OpenGoogleSignInSDK.swift
+++ b/Sources/OpenGoogleSignInSDK/OpenGoogleSignInSDK.swift
@@ -238,7 +238,7 @@ public final class OpenGoogleSignIn: NSObject {
         guard let profileURL = OpenGoogleSignIn.profileURL else { return nil }
         
         var request = URLRequest(url: profileURL)
-        request.setValue("Bearer \(user.accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("Bearer " + user.accessToken, forHTTPHeaderField: "Authorization")
         
         return request
     }

--- a/Sources/OpenGoogleSignInSDK/OpenGoogleSignInSDK.swift
+++ b/Sources/OpenGoogleSignInSDK/OpenGoogleSignInSDK.swift
@@ -156,12 +156,7 @@ public final class OpenGoogleSignIn: NSObject {
             case let .success(data):
                 do {
                     let user = try self.decodeUser(from: data)
-                    
-                    if self.scopes.contains(.email) || self.scopes.contains(.profile) {
-                        self.fetchProfile(user: user, completion: completion)
-                    } else {
-                        completion(.success(user))
-                    }
+                    self.fetchProfile(user: user, completion: completion)
                 } catch {
                     completion(.failure(.tokenDecodingError(error)))
                 }

--- a/Sources/OpenGoogleSignInSDK/OpenGoogleSignInSDK.swift
+++ b/Sources/OpenGoogleSignInSDK/OpenGoogleSignInSDK.swift
@@ -162,6 +162,10 @@ public final class OpenGoogleSignIn: NSObject {
                         return
                     }
                     
+                    // To obtain profile data we need to make another request.
+                    // If the request fails, we only log the error
+                    // and call completion with the `GoogleUser` object
+                    // without his profile info.
                     self.makeRequest(profileRequest) { result in
                         switch result {
                         case let .success(data):
@@ -172,7 +176,8 @@ public final class OpenGoogleSignIn: NSObject {
                             completion(.success(user))
                             
                         case let .failure(error):
-                            completion(.failure(error))
+                            os_log(.error, "Profile request failed with error: %@", error.localizedDescription)
+                            completion(.success(user))
                         }
                     }
                 } catch {
@@ -185,6 +190,7 @@ public final class OpenGoogleSignIn: NSObject {
         }
     }
     
+    /// Wrapper for easier `URLRequest` handling.
     private func makeRequest(_ request: URLRequest, completion: @escaping (Result<Data, GoogleSignInError>) -> Void) {
         let task = session.dataTask(with: request) { data, response, error in
             if let error = error {

--- a/Tests/OpenGoogleSignInSDKTests/OpenGoogleSignInSDKTests.swift
+++ b/Tests/OpenGoogleSignInSDKTests/OpenGoogleSignInSDKTests.swift
@@ -74,6 +74,28 @@ final class OpenGoogleSignInTests: XCTestCase {
         XCTAssertNotNil(mockDelegate.user)
     }
     
+    // Since `URL` has optional initializer we need to
+    // check if the URL provided by us is valid and
+    // therefore we don't need to worry about this edge case.
+    func test_tokenRequest_isValid() {
+        // When
+        let request = sharedInstance.makeTokenRequest(with: "code")
+        
+        // Then
+        XCTAssertNotNil(request)
+    }
+    
+    // Since `URL` has optional initializer we need to
+    // check if the URL provided by us is valid and
+    // therefore we don't need to worry about this edge case.
+    func test_profileRequest_isValid() {
+        // Given
+        let user = mockUser()
+        
+        // Then
+        XCTAssertNotNil(sharedInstance.makeProfileRequest(user: user))
+    }
+    
     // MARK: - Private helpers
     
     private func mockUser() -> GoogleUser {


### PR DESCRIPTION
We add an additional request to Google API to obtain user's profile data.

After successful authentication, another request to Google API is made. If this request succeeds we try to decode the response and then append the data to `GoogleUser` object.

If the request fails, error is logged and `GoogleUser` object without profile data is sent in success completion block.

This PR fixes #2