### PR TITLE
Added error handling for user cancelling flow

### DIFF
--- a/Sources/OpenGoogleSignInSDK/OpenGoogleSignInSDK.swift
+++ b/Sources/OpenGoogleSignInSDK/OpenGoogleSignInSDK.swift
@@ -106,7 +106,13 @@ public final class OpenGoogleSignIn: NSObject {
             url: authURL,
             callbackURLScheme: clientID
         ) { [weak self] callbackURL, error in
-            guard let callbackURL = callbackURL else { return }
+            guard let callbackURL = callbackURL else {
+                if error != nil {
+                    // No callback URL with error means user cancelled the flow
+                    self?.delegate?.sign(didSignInFor: nil, withError: .userCancelledSignInFlow)
+                }
+                return
+            }
 
             if let error = error {
                 // Throw error if received


### PR DESCRIPTION
So far when user cancelled the sign in flow no error was delivered to delegate, even though this error was defined. 

If no callback url is delivered and only error is present, `userCancelledSignInFlow` is now being delivered to delegate.