### PR TITLE
Dependency managers support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .DS_Store
 /.build
 /Packages
-/*.xcodeproj
 xcuserdata/
 DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# CHANGELOG
+
+- please enter new entries in format 
+
+```
+- <description> (#<PR_number>, kudos to @<author>)
+```
+
+## Next
+
+### Added
+
+- `audience` parameter for server-side sign after a token is obtain (#9, kudos to @paweldudek)
+
+## 1.1.0
+
+### Added
+
+- Load user's profile (#6, kudos to @LukasHromadnik)
+
+## 1.0.0
+
+- 🎉 Initial release (kudos to @IgorRosocha)

--- a/OpenGoogleSignInSDK.podspec
+++ b/OpenGoogleSignInSDK.podspec
@@ -1,0 +1,20 @@
+
+Pod::Spec.new do |s|
+  s.name = "OpenGoogleSignInSDK"
+  s.version = "1.0.0"
+  s.summary = "OpenGoogleSignInSDK takes care of Google Sign-In flow using OAuth 2.0."
+  s.description = <<-DESC
+  OpenGoogleSignInSDK is an open-source library which takes care of Google Sign-In flow using OAuth 2.0 and can be used as an alternative to official GoogleSignInSDK
+  DESC
+  s.homepage = "https://github.com/AckeeCZ/OpenGoogleSignInSDK"
+  s.license = { :type => 'MIT', :file => 'LICENSE' }
+  s.authors = { "Ackee" => "info@ackee.cz" }
+  s.source = { :git => "https://github.com/AckeeCZ/OpenGoogleSignInSDK.git", :tag => s.version }
+
+  s.ios.deployment_target = "12.0"
+  s.osx.deployment_target = "10.15"
+
+  s.swift_version = "5.4.2"
+
+  s.source_files = "Sources/**/*.swift"
+end

--- a/OpenGoogleSignInSDK.podspec
+++ b/OpenGoogleSignInSDK.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name = "OpenGoogleSignInSDK"
-  s.version = "1.0.0"
+  s.version = "1.1.0"
   s.summary = "OpenGoogleSignInSDK takes care of Google Sign-In flow using OAuth 2.0."
   s.description = <<-DESC
   OpenGoogleSignInSDK is an open-source library which takes care of Google Sign-In flow using OAuth 2.0 and can be used as an alternative to official GoogleSignInSDK

--- a/OpenGoogleSignInSDK.xcodeproj/OpenGoogleSignInSDKTests_Info.plist
+++ b/OpenGoogleSignInSDK.xcodeproj/OpenGoogleSignInSDKTests_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>BNDL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/OpenGoogleSignInSDK.xcodeproj/OpenGoogleSignInSDK_Info.plist
+++ b/OpenGoogleSignInSDK.xcodeproj/OpenGoogleSignInSDK_Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>$(EXECUTABLE_NAME)</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundlePackageType</key>
+  <string>FMWK</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>$(CURRENT_PROJECT_VERSION)</string>
+  <key>NSPrincipalClass</key>
+  <string></string>
+</dict>
+</plist>

--- a/OpenGoogleSignInSDK.xcodeproj/project.pbxproj
+++ b/OpenGoogleSignInSDK.xcodeproj/project.pbxproj
@@ -1,0 +1,543 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		"OpenGoogleSignInSDK::OpenGoogleSignInSDKPackageTests::ProductTarget" /* OpenGoogleSignInSDKPackageTests */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = OBJ_45 /* Build configuration list for PBXAggregateTarget "OpenGoogleSignInSDKPackageTests" */;
+			buildPhases = (
+			);
+			dependencies = (
+				OBJ_48 /* PBXTargetDependency */,
+			);
+			name = OpenGoogleSignInSDKPackageTests;
+			productName = OpenGoogleSignInSDKPackageTests;
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		A399713026A6A175009A3975 /* JSONDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A399712F26A6A175009A3975 /* JSONDecoder.swift */; };
+		OBJ_33 /* GoogleSignInError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* GoogleSignInError.swift */; };
+		OBJ_34 /* GoogleSignInScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* GoogleSignInScope.swift */; };
+		OBJ_35 /* GoogleUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* GoogleUser.swift */; };
+		OBJ_36 /* OpenGoogleSignInSDK.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* OpenGoogleSignInSDK.swift */; };
+		OBJ_43 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
+		OBJ_54 /* MockOpenGoogleSignInDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* MockOpenGoogleSignInDelegate.swift */; };
+		OBJ_55 /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_18 /* MockURLSession.swift */; };
+		OBJ_56 /* MockURLSessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_19 /* MockURLSessionDataTask.swift */; };
+		OBJ_57 /* OpenGoogleSignInSDKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* OpenGoogleSignInSDKTests.swift */; };
+		OBJ_59 /* OpenGoogleSignInSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "OpenGoogleSignInSDK::OpenGoogleSignInSDK::Product" /* OpenGoogleSignInSDK.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		A3545F8C26A69558000C9C3C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "OpenGoogleSignInSDK::OpenGoogleSignInSDK";
+			remoteInfo = OpenGoogleSignInSDK;
+		};
+		A3545F8D26A695D3000C9C3C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "OpenGoogleSignInSDK::OpenGoogleSignInSDKTests";
+			remoteInfo = OpenGoogleSignInSDKTests;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		A399712F26A6A175009A3975 /* JSONDecoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONDecoder.swift; sourceTree = "<group>"; };
+		OBJ_10 /* GoogleSignInError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleSignInError.swift; sourceTree = "<group>"; };
+		OBJ_11 /* GoogleSignInScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleSignInScope.swift; sourceTree = "<group>"; };
+		OBJ_12 /* GoogleUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleUser.swift; sourceTree = "<group>"; };
+		OBJ_13 /* OpenGoogleSignInSDK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenGoogleSignInSDK.swift; sourceTree = "<group>"; };
+		OBJ_17 /* MockOpenGoogleSignInDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOpenGoogleSignInDelegate.swift; sourceTree = "<group>"; };
+		OBJ_18 /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
+		OBJ_19 /* MockURLSessionDataTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSessionDataTask.swift; sourceTree = "<group>"; };
+		OBJ_20 /* OpenGoogleSignInSDKTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenGoogleSignInSDKTests.swift; sourceTree = "<group>"; };
+		OBJ_24 /* Resources */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Resources; sourceTree = SOURCE_ROOT; };
+		OBJ_25 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		OBJ_26 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		OBJ_27 /* OpenGoogleSignInSDK.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = OpenGoogleSignInSDK.podspec; sourceTree = "<group>"; };
+		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		"OpenGoogleSignInSDK::OpenGoogleSignInSDK::Product" /* OpenGoogleSignInSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = OpenGoogleSignInSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"OpenGoogleSignInSDK::OpenGoogleSignInSDKTests::Product" /* OpenGoogleSignInSDKTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = OpenGoogleSignInSDKTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		OBJ_37 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_58 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_59 /* OpenGoogleSignInSDK.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		OBJ_14 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_15 /* OpenGoogleSignInSDKTests */,
+			);
+			name = Tests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_15 /* OpenGoogleSignInSDKTests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_16 /* Mocks */,
+				OBJ_20 /* OpenGoogleSignInSDKTests.swift */,
+			);
+			name = OpenGoogleSignInSDKTests;
+			path = Tests/OpenGoogleSignInSDKTests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_16 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_17 /* MockOpenGoogleSignInDelegate.swift */,
+				OBJ_18 /* MockURLSession.swift */,
+				OBJ_19 /* MockURLSessionDataTask.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
+		OBJ_21 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				"OpenGoogleSignInSDK::OpenGoogleSignInSDK::Product" /* OpenGoogleSignInSDK.framework */,
+				"OpenGoogleSignInSDK::OpenGoogleSignInSDKTests::Product" /* OpenGoogleSignInSDKTests.xctest */,
+			);
+			name = Products;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		OBJ_5 = {
+			isa = PBXGroup;
+			children = (
+				OBJ_6 /* Package.swift */,
+				OBJ_7 /* Sources */,
+				OBJ_14 /* Tests */,
+				OBJ_21 /* Products */,
+				OBJ_24 /* Resources */,
+				OBJ_25 /* LICENSE */,
+				OBJ_26 /* README.md */,
+				OBJ_27 /* OpenGoogleSignInSDK.podspec */,
+			);
+			sourceTree = "<group>";
+		};
+		OBJ_7 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_8 /* OpenGoogleSignInSDK */,
+			);
+			name = Sources;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_8 /* OpenGoogleSignInSDK */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_9 /* Model */,
+				OBJ_13 /* OpenGoogleSignInSDK.swift */,
+				A399712F26A6A175009A3975 /* JSONDecoder.swift */,
+			);
+			name = OpenGoogleSignInSDK;
+			path = Sources/OpenGoogleSignInSDK;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_9 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_10 /* GoogleSignInError.swift */,
+				OBJ_11 /* GoogleSignInScope.swift */,
+				OBJ_12 /* GoogleUser.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		"OpenGoogleSignInSDK::OpenGoogleSignInSDK" /* OpenGoogleSignInSDK */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_29 /* Build configuration list for PBXNativeTarget "OpenGoogleSignInSDK" */;
+			buildPhases = (
+				OBJ_32 /* Sources */,
+				OBJ_37 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = OpenGoogleSignInSDK;
+			productName = OpenGoogleSignInSDK;
+			productReference = "OpenGoogleSignInSDK::OpenGoogleSignInSDK::Product" /* OpenGoogleSignInSDK.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"OpenGoogleSignInSDK::OpenGoogleSignInSDKTests" /* OpenGoogleSignInSDKTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_50 /* Build configuration list for PBXNativeTarget "OpenGoogleSignInSDKTests" */;
+			buildPhases = (
+				OBJ_53 /* Sources */,
+				OBJ_58 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_60 /* PBXTargetDependency */,
+			);
+			name = OpenGoogleSignInSDKTests;
+			productName = OpenGoogleSignInSDKTests;
+			productReference = "OpenGoogleSignInSDK::OpenGoogleSignInSDKTests::Product" /* OpenGoogleSignInSDKTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		"OpenGoogleSignInSDK::SwiftPMPackageDescription" /* OpenGoogleSignInSDKPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_39 /* Build configuration list for PBXNativeTarget "OpenGoogleSignInSDKPackageDescription" */;
+			buildPhases = (
+				OBJ_42 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = OpenGoogleSignInSDKPackageDescription;
+			productName = OpenGoogleSignInSDKPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		OBJ_1 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftMigration = 9999;
+				LastUpgradeCheck = 9999;
+			};
+			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "OpenGoogleSignInSDK" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = OBJ_5;
+			productRefGroup = OBJ_21 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				"OpenGoogleSignInSDK::OpenGoogleSignInSDK" /* OpenGoogleSignInSDK */,
+				"OpenGoogleSignInSDK::SwiftPMPackageDescription" /* OpenGoogleSignInSDKPackageDescription */,
+				"OpenGoogleSignInSDK::OpenGoogleSignInSDKPackageTests::ProductTarget" /* OpenGoogleSignInSDKPackageTests */,
+				"OpenGoogleSignInSDK::OpenGoogleSignInSDKTests" /* OpenGoogleSignInSDKTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		OBJ_32 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_33 /* GoogleSignInError.swift in Sources */,
+				OBJ_34 /* GoogleSignInScope.swift in Sources */,
+				A399713026A6A175009A3975 /* JSONDecoder.swift in Sources */,
+				OBJ_35 /* GoogleUser.swift in Sources */,
+				OBJ_36 /* OpenGoogleSignInSDK.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_42 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_43 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_53 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_54 /* MockOpenGoogleSignInDelegate.swift in Sources */,
+				OBJ_55 /* MockURLSession.swift in Sources */,
+				OBJ_56 /* MockURLSessionDataTask.swift in Sources */,
+				OBJ_57 /* OpenGoogleSignInSDKTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		OBJ_48 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "OpenGoogleSignInSDK::OpenGoogleSignInSDKTests" /* OpenGoogleSignInSDKTests */;
+			targetProxy = A3545F8D26A695D3000C9C3C /* PBXContainerItemProxy */;
+		};
+		OBJ_60 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "OpenGoogleSignInSDK::OpenGoogleSignInSDK" /* OpenGoogleSignInSDK */;
+			targetProxy = A3545F8C26A69558000C9C3C /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		OBJ_3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SWIFT_PACKAGE=1",
+					"DEBUG=1",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE DEBUG";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		OBJ_30 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = OpenGoogleSignInSDK.xcodeproj/OpenGoogleSignInSDK_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = OpenGoogleSignInSDK;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = OpenGoogleSignInSDK;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_31 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = OpenGoogleSignInSDK.xcodeproj/OpenGoogleSignInSDK_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = OpenGoogleSignInSDK;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = OpenGoogleSignInSDK;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_OPTIMIZATION_LEVEL = s;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SWIFT_PACKAGE=1",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		OBJ_40 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk -package-description-version 5.3.0";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		OBJ_41 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk -package-description-version 5.3.0";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		OBJ_46 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		OBJ_47 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		OBJ_51 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = OpenGoogleSignInSDK.xcodeproj/OpenGoogleSignInSDKTests_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = OpenGoogleSignInSDKTests;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 7.0;
+			};
+			name = Debug;
+		};
+		OBJ_52 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = OpenGoogleSignInSDK.xcodeproj/OpenGoogleSignInSDKTests_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = OpenGoogleSignInSDKTests;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 7.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		OBJ_2 /* Build configuration list for PBXProject "OpenGoogleSignInSDK" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_3 /* Debug */,
+				OBJ_4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_29 /* Build configuration list for PBXNativeTarget "OpenGoogleSignInSDK" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_30 /* Debug */,
+				OBJ_31 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_39 /* Build configuration list for PBXNativeTarget "OpenGoogleSignInSDKPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_40 /* Debug */,
+				OBJ_41 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_45 /* Build configuration list for PBXAggregateTarget "OpenGoogleSignInSDKPackageTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_46 /* Debug */,
+				OBJ_47 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_50 /* Build configuration list for PBXNativeTarget "OpenGoogleSignInSDKTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_51 /* Debug */,
+				OBJ_52 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = OBJ_1 /* Project object */;
+}

--- a/OpenGoogleSignInSDK.xcodeproj/project.pbxproj
+++ b/OpenGoogleSignInSDK.xcodeproj/project.pbxproj
@@ -311,7 +311,7 @@
 					"SWIFT_PACKAGE=1",
 					"DEBUG=1",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -395,7 +395,7 @@
 					"$(inherited)",
 					"SWIFT_PACKAGE=1",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;

--- a/OpenGoogleSignInSDK.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/OpenGoogleSignInSDK.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/OpenGoogleSignInSDK.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/OpenGoogleSignInSDK.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/OpenGoogleSignInSDK.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/OpenGoogleSignInSDK.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
+    <false/>
+</dict>
+</plist>

--- a/OpenGoogleSignInSDK.xcodeproj/xcshareddata/xcschemes/OpenGoogleSignInSDK.xcscheme
+++ b/OpenGoogleSignInSDK.xcodeproj/xcshareddata/xcschemes/OpenGoogleSignInSDK.xcscheme
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "9999"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "OpenGoogleSignInSDK::OpenGoogleSignInSDK"
+               BuildableName = "OpenGoogleSignInSDK.framework"
+               BlueprintName = "OpenGoogleSignInSDK"
+               ReferencedContainer = "container:OpenGoogleSignInSDK.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "OpenGoogleSignInSDK::OpenGoogleSignInSDKTests"
+               BuildableName = "OpenGoogleSignInSDKTests.xctest"
+               BlueprintName = "OpenGoogleSignInSDKTests"
+               ReferencedContainer = "container:OpenGoogleSignInSDK.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.swift
+++ b/Package.swift
@@ -10,15 +10,18 @@ let package = Package(
     products: [
         .library(
             name: "OpenGoogleSignInSDK",
-            targets: ["OpenGoogleSignInSDK"]),
+            targets: ["OpenGoogleSignInSDK"]
+        ),
     ],
     dependencies: [],
     targets: [
         .target(
             name: "OpenGoogleSignInSDK",
-            dependencies: []),
+            dependencies: []
+        ),
         .testTarget(
             name: "OpenGoogleSignInSDKTests",
-            dependencies: ["OpenGoogleSignInSDK"]),
+            dependencies: ["OpenGoogleSignInSDK"]
+        ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(
             name: "OpenGoogleSignInSDK",
             targets: ["OpenGoogleSignInSDK"]
-        ),
+        )
     ],
     dependencies: [],
     targets: [
@@ -22,6 +22,6 @@ let package = Package(
         .testTarget(
             name: "OpenGoogleSignInSDKTests",
             dependencies: ["OpenGoogleSignInSDK"]
-        ),
+        )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
     name: "OpenGoogleSignInSDK",
     platforms: [
         .iOS(.v12),
-        .macOS("10.9")
+        .macOS(.v10_15)
     ],
     products: [
         .library(

--- a/Sources/OpenGoogleSignInSDK/Model/GoogleSignInError.swift
+++ b/Sources/OpenGoogleSignInSDK/Model/GoogleSignInError.swift
@@ -5,34 +5,10 @@ public enum GoogleSignInError: Error, Equatable {
     case authenticationError(Error)
     case invalidCode
     case invalidResponse
-    case invalidTokenRequest
     case networkError(Error)
     case tokenDecodingError(Error)
     case userCancelledSignInFlow
     case noProfile(Error)
-}
-
-extension GoogleSignInError: LocalizedError {
-    public var errorDescription: String? {
-        switch self {
-        case let .authenticationError(error):
-            return "authenticationError, underlying error \(error.localizedDescription)"
-        case .invalidCode:
-            return "invalidCode"
-        case .invalidResponse:
-            return "invalidResponse"
-        case .invalidTokenRequest:
-            return "invalidTokenRequest"
-        case let .networkError(error):
-            return "network, underlying error \(error.localizedDescription)"
-        case let .tokenDecodingError(error):
-            return "tokenDecoding, underlying error \(error.localizedDescription)"
-        case .userCancelledSignInFlow:
-            return "userCancelledSignInFlow"
-        case let .noProfile(error):
-            return "noProfile, underlying error \(error.localizedDescription)"
-        }
-    }
 }
 
 public func == (lhs: Error, rhs: Error) -> Bool {
@@ -42,7 +18,7 @@ public func == (lhs: Error, rhs: Error) -> Bool {
     return error1.domain == error2.domain && error1.code == error2.code && "\(lhs)" == "\(rhs)"
 }
 
-extension Equatable where Self : Error {
+extension Equatable where Self: Error {
     public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs as Error == rhs as Error
     }

--- a/Sources/OpenGoogleSignInSDK/Model/GoogleSignInError.swift
+++ b/Sources/OpenGoogleSignInSDK/Model/GoogleSignInError.swift
@@ -5,10 +5,34 @@ public enum GoogleSignInError: Error, Equatable {
     case authenticationError(Error)
     case invalidCode
     case invalidResponse
+    case invalidTokenRequest
     case networkError(Error)
     case tokenDecodingError(Error)
     case userCancelledSignInFlow
     case noProfile(Error)
+}
+
+extension GoogleSignInError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case let .authenticationError(error):
+            return "authenticationError, underlying error \(error.localizedDescription)"
+        case .invalidCode:
+            return "invalidCode"
+        case .invalidResponse:
+            return "invalidResponse"
+        case .invalidTokenRequest:
+            return "invalidTokenRequest"
+        case let .networkError(error):
+            return "network, underlying error \(error.localizedDescription)"
+        case let .tokenDecodingError(error):
+            return "tokenDecoding, underlying error \(error.localizedDescription)"
+        case .userCancelledSignInFlow:
+            return "userCancelledSignInFlow"
+        case let .noProfile(error):
+            return "noProfile, underlying error \(error.localizedDescription)"
+        }
+    }
 }
 
 public func == (lhs: Error, rhs: Error) -> Bool {

--- a/Sources/OpenGoogleSignInSDK/Model/GoogleUser.swift
+++ b/Sources/OpenGoogleSignInSDK/Model/GoogleUser.swift
@@ -2,44 +2,44 @@ import Foundation
 
 /// Google sign-in user account.
 public struct GoogleUser: Codable, Equatable {
-    
+
     /// User's profile info.
     ///
     /// All the properties are optional according
     /// to the [documentation](https://googleapis.dev/nodejs/googleapis/latest/oauth2/interfaces/Schema$Userinfo.html#info).
     public struct Profile: Codable, Equatable {
-        
+
         /// The obfuscated ID of the user.
         public let id: String?
-        
+
         /// The user's email address.
         public let email: String?
-        
+
         /// Boolean flag which is true if the email address is verified.
         /// Always verified because we only return the user's primary email address.
         public let verifiedEmail: Bool?
-        
+
         /// The user's full name.
         public let name: String?
-        
+
         /// The user's first name.
         public let givenName: String?
-        
+
         /// The user's last name.
         public let familyName: String?
-        
+
         /// The user's gender.
         public let gender: String?
-        
+
         /// URL of the profile page.
         public let link: URL?
-        
+
         /// URL of the user's picture image.
         public let picture: URL?
-        
+
         /// The hosted domain e.g. example.com if the user is Google apps user.
         public let hd: String?
-        
+
         /// The user's preferred locale.
         public let locale: String?
     }

--- a/Sources/OpenGoogleSignInSDK/OpenGoogleSignInSDK.swift
+++ b/Sources/OpenGoogleSignInSDK/OpenGoogleSignInSDK.swift
@@ -1,6 +1,13 @@
 import AuthenticationServices
 import OSLog
+
+#if os(iOS)
 import UIKit
+public typealias ViewController = UIViewController
+#elseif os(macOS)
+import AppKit
+public typealias ViewController = NSViewController
+#endif
 
 /// Google sign-in delegate.
 public protocol OpenGoogleSignInDelegate: AnyObject {
@@ -36,16 +43,16 @@ public final class OpenGoogleSignIn: NSObject {
     
     /// View controller to present Google sign-in flow.
     /// Needs to be set for presenting to work correctly.
-    public weak var presentingViewController: UIViewController? = nil
-
+    public weak var presentingViewController: ViewController? = nil
+    
     // MARK: - Private properties
 
     /// Session used to authenticate a user with Google sign-in.
     private var authenticationSession: ASWebAuthenticationSession? = nil
-
+    
     /// Google API OAuth 2.0 token url.
     private static let tokenURL: URL? = URL(string: "https://www.googleapis.com/oauth2/v4/token")
-
+    
     /// Google API profile url
     private static let profileURL: URL? = URL(string: "https://www.googleapis.com/oauth2/v1/userinfo?alt=json")
 
@@ -221,7 +228,7 @@ public final class OpenGoogleSignIn: NSObject {
     }
     
     /// Returns `URLRequest` to retrieve Google sign-in OAuth 2.0 token using arameters provided by the app.
-    func makeTokenRequest(with code: String) -> URLRequest? {
+    private func makeTokenRequest(with code: String) -> URLRequest? {
         guard let tokenURL = OpenGoogleSignIn.tokenURL else { return nil }
 
         var request = URLRequest(url: tokenURL)
@@ -235,6 +242,7 @@ public final class OpenGoogleSignIn: NSObject {
             "grant_type": "authorization_code",
             "redirect_uri": redirectURI
         ]
+        
         if let audience = audience {
             parameters["audience"] = audience
         }
@@ -249,7 +257,7 @@ public final class OpenGoogleSignIn: NSObject {
     }
 
     /// Returns `URLRequest` to retrieve user's profile data
-    func makeProfileRequest(user: GoogleUser) -> URLRequest? {
+    private func makeProfileRequest(user: GoogleUser) -> URLRequest? {
         guard let profileURL = OpenGoogleSignIn.profileURL else { return nil }
 
         var request = URLRequest(url: profileURL)
@@ -263,6 +271,6 @@ public final class OpenGoogleSignIn: NSObject {
 
 extension OpenGoogleSignIn: ASWebAuthenticationPresentationContextProviding {
     public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        UIApplication.shared.windows.first { $0.isKeyWindow } ?? ASPresentationAnchor()
+        presentingViewController?.view.window ?? ASPresentationAnchor()
     }
 }

--- a/Sources/OpenGoogleSignInSDK/OpenGoogleSignInSDK.swift
+++ b/Sources/OpenGoogleSignInSDK/OpenGoogleSignInSDK.swift
@@ -21,38 +21,38 @@ public final class OpenGoogleSignIn: NSObject {
     // MARK: - Public properties
 
     public weak var delegate: OpenGoogleSignInDelegate?
-    
+
     /// The client ID of the app.
     /// It is required for communication with Google API to work.
     public var clientID: String = ""
-    
+
     public var audience: String?
 
     /// Client secret.
     /// It is only used when exchanging the authorization code for an access token.
     public var clientSecret: String = ""
-    
+
     /// `URLSession` used to perform data tasks.
     public var session: URLSession = URLSession.shared
-    
+
     /// Shared `OpenGoogleSignIn` instance
     public static let shared: OpenGoogleSignIn = OpenGoogleSignIn()
-    
+
     /// API scopes requested by the app
     public var scopes: Set<GoogleSignInScope> = [.email, .openID, .profile]
-    
+
     /// View controller to present Google sign-in flow.
     /// Needs to be set for presenting to work correctly.
-    public weak var presentingViewController: ViewController? = nil
-    
+    public weak var presentingViewController: ViewController?
+
     // MARK: - Private properties
 
     /// Session used to authenticate a user with Google sign-in.
-    private var authenticationSession: ASWebAuthenticationSession? = nil
-    
+    private var authenticationSession: ASWebAuthenticationSession?
+
     /// Google API OAuth 2.0 token url.
     private static let tokenURL: URL? = URL(string: "https://www.googleapis.com/oauth2/v4/token")
-    
+
     /// Google API profile url
     private static let profileURL: URL? = URL(string: "https://www.googleapis.com/oauth2/v1/userinfo?alt=json")
 
@@ -79,7 +79,7 @@ public final class OpenGoogleSignIn: NSObject {
             URLQueryItem(name: "client_id", value: clientID),
             URLQueryItem(name: "redirect_uri", value: redirectURI),
             URLQueryItem(name: "response_type", value: "code"),
-            URLQueryItem(name: "scope", value: scopes),
+            URLQueryItem(name: "scope", value: scopes)
         ]
 
         return components.url!
@@ -144,7 +144,7 @@ public final class OpenGoogleSignIn: NSObject {
     }
 
     // MARK: - Private helpers
-    
+
     /// Decodes `GoogleUser` from OAuth 2.0 response.
     private func decodeUser(from data: Data) throws -> GoogleUser {
         try JSONDecoder.app.decode(GoogleUser.self, from: data)
@@ -195,7 +195,7 @@ public final class OpenGoogleSignIn: NSObject {
                 let profile = try? JSONDecoder.app.decode(GoogleUser.Profile.self, from: data)
                 user.profile = profile
                 completion(.success(user))
-                
+
             case let .failure(error):
                 completion(.failure(.noProfile(error)))
             }
@@ -219,14 +219,14 @@ public final class OpenGoogleSignIn: NSObject {
         }
         task.resume()
     }
-    
+
     /// Returns `code` parsed from provided `redirectURL`.
     private func parseCode(from redirectURL: URL) -> String? {
         let components = URLComponents(url: redirectURL, resolvingAgainstBaseURL: false)
 
         return components?.queryItems?.first(where: { $0.name == "code" })?.value
     }
-    
+
     /// Returns `URLRequest` to retrieve Google sign-in OAuth 2.0 token using arameters provided by the app.
     private func makeTokenRequest(with code: String) -> URLRequest? {
         guard let tokenURL = OpenGoogleSignIn.tokenURL else { return nil }
@@ -242,7 +242,7 @@ public final class OpenGoogleSignIn: NSObject {
             "grant_type": "authorization_code",
             "redirect_uri": redirectURI
         ]
-        
+
         if let audience = audience {
             parameters["audience"] = audience
         }
@@ -252,7 +252,7 @@ public final class OpenGoogleSignIn: NSObject {
             .joined(separator: "&")
 
         request.httpBody = body.data(using: .utf8)
-        
+
         return request
     }
 

--- a/TapestryConfig.swift
+++ b/TapestryConfig.swift
@@ -4,7 +4,14 @@ let config = TapestryConfig(
     release: Release(
         actions: [
             .pre(.docsUpdate),
-            .pre(.dependenciesCompatibility([.cocoapods, .carthage, .spm(.all)]))
+            .pre(.dependenciesCompatibility([
+                .cocoapods,
+                // Cannot use Carthage check because
+                // we need to run carthage.sh or `--use-xcframeworks`.
+                // Will be resolved in the future
+                // .carthage,
+                .spm(.all)
+            ]))
         ],
         add: [
             "README.md",

--- a/TapestryConfig.swift
+++ b/TapestryConfig.swift
@@ -1,0 +1,17 @@
+import TapestryDescription
+
+let config = TapestryConfig(
+    release: Release(
+        actions: [
+            .pre(.docsUpdate),
+            .pre(.dependenciesCompatibility([.cocoapods, .carthage, .spm(.all)]))
+        ],
+        add: [
+            "README.md",
+            "OpenGoogleSignInSDK.podspec",
+            "CHANGELOG.md"
+        ],
+        commitMessage: "🔖 Version \(Argument.version)",
+        push: false
+    )
+)

--- a/Tests/OpenGoogleSignInSDKTests/Mocks/MockOpenGoogleSignInDelegate.swift
+++ b/Tests/OpenGoogleSignInSDKTests/Mocks/MockOpenGoogleSignInDelegate.swift
@@ -4,20 +4,20 @@ import XCTest
 final class MockOpenGoogleSignInDelegate: OpenGoogleSignInDelegate {
     var user: GoogleUser?
     var error: GoogleSignInError?
-    
+
     private var expectation: XCTestExpectation?
     private let testCase: XCTestCase
-    
+
     init(testCase: XCTestCase) {
         self.testCase = testCase
     }
-    
+
     func expectSignInFinish() {
         expectation = testCase.expectation(description: "Expect sign-in flow to finish")
     }
-    
+
     // MARK: - OAuthGoogleSignInDelegate
-    
+
     func sign(didSignInFor user: GoogleUser?, withError error: GoogleSignInError?) {
         self.user = user
         self.error = error

--- a/Tests/OpenGoogleSignInSDKTests/Mocks/MockURLSession.swift
+++ b/Tests/OpenGoogleSignInSDKTests/Mocks/MockURLSession.swift
@@ -3,14 +3,14 @@ import Foundation
 final class MockURLSession: URLSession {
     var data: Data?
     var error: Error?
-    
+
     override func dataTask(
         with request: URLRequest,
         completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
     ) -> URLSessionDataTask {
         let data = self.data
         let error = self.error
-        
+
         return MockURLSessionDataTask {
             completionHandler(data, nil, error)
         }

--- a/Tests/OpenGoogleSignInSDKTests/OpenGoogleSignInSDKTests.swift
+++ b/Tests/OpenGoogleSignInSDKTests/OpenGoogleSignInSDKTests.swift
@@ -5,45 +5,45 @@ final class OpenGoogleSignInTests: XCTestCase {
     var sharedInstance: OpenGoogleSignIn!
     var mockDelegate: MockOpenGoogleSignInDelegate!
     var session: MockURLSession!
-    
+
     override func setUp() {
         super.setUp()
 
         sharedInstance = OpenGoogleSignIn.shared
-        
+
         mockDelegate = MockOpenGoogleSignInDelegate(testCase: self)
         sharedInstance.delegate = mockDelegate
-        
+
         session = MockURLSession()
     }
-    
+
     override func tearDown() {
         session = nil
 
         super.tearDown()
     }
-    
+
     func test_invalidCodeError_isThrown() {
         // Given
         let url = URL(string: "https://google.com")!
         mockDelegate.expectSignInFinish()
-        
+
         // When
         sharedInstance.handle(url)
         waitForExpectations(timeout: 0.5)
-        
+
         // Then
         XCTAssertEqual(mockDelegate.error, GoogleSignInError.invalidCode)
         XCTAssertNil(mockDelegate.user)
     }
-    
+
     func test_invalidResponseError_isThrown() {
         // Given
         let url = URL(string: "https://google.com?code=1234")!
         mockDelegate.expectSignInFinish()
         session.data = nil
         sharedInstance.session = session
-        
+
         // When
         sharedInstance.handle(url)
         waitForExpectations(timeout: 0.5)
@@ -52,52 +52,52 @@ final class OpenGoogleSignInTests: XCTestCase {
         XCTAssertEqual(mockDelegate.error, GoogleSignInError.invalidResponse)
         XCTAssertNil(mockDelegate.user)
     }
-    
+
     func test_validUserIsReceived() {
         // Given
         let url = URL(string: "https://google.com?code=1234")!
         mockDelegate.expectSignInFinish()
-        
+
         let user = mockUser()
         let encoder = JSONEncoder()
         guard let data = try? encoder.encode(user) else { return }
-        
+
         session.data = data
         sharedInstance.session = session
-    
+
         // When
         sharedInstance.handle(url)
         waitForExpectations(timeout: 0.5)
-        
+
         // Then
         XCTAssertNil(mockDelegate.error)
         XCTAssertNotNil(mockDelegate.user)
     }
-    
+
     // Since `URL` has optional initializer we need to
     // check if the URL provided by us is valid and
     // therefore we don't need to worry about this edge case.
     func test_tokenRequest_isValid() {
         // When
         let request = sharedInstance.makeTokenRequest(with: "code")
-        
+
         // Then
         XCTAssertNotNil(request)
     }
-    
+
     // Since `URL` has optional initializer we need to
     // check if the URL provided by us is valid and
     // therefore we don't need to worry about this edge case.
     func test_profileRequest_isValid() {
         // Given
         let user = mockUser()
-        
+
         // Then
         XCTAssertNotNil(sharedInstance.makeProfileRequest(user: user))
     }
-    
+
     // MARK: - Private helpers
-    
+
     private func mockUser() -> GoogleUser {
         GoogleUser(
             accessToken: "accessToken",


### PR DESCRIPTION
In this PR we added support for 3rd dependency managers:
* Cocoapods
* Carthage

The whole release is possible to be done using Tapestry.

Some code had to be updated to be buildable for macOS platform.

This PR resolves #3 and #4